### PR TITLE
feat: exclude hidden directories from file search

### DIFF
--- a/lua/markdown-notes/links.lua
+++ b/lua/markdown-notes/links.lua
@@ -12,7 +12,7 @@ function M.search_and_link()
   fzf.files({
     prompt = "Link to Note> ",
     cwd = vim.fn.expand(config.options.vault_path),
-    find_opts = "-name '*.md' -type f -not -path '*/.*'",
+    cmd = "find . -name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,
     formatter = nil,

--- a/lua/markdown-notes/links.lua
+++ b/lua/markdown-notes/links.lua
@@ -12,7 +12,7 @@ function M.search_and_link()
   fzf.files({
     prompt = "Link to Note> ",
     cwd = vim.fn.expand(config.options.vault_path),
-    find_opts = "-name '*.md' -type f",
+    find_opts = "-name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,
     formatter = nil,
@@ -55,7 +55,7 @@ function M.follow_link()
       
       -- Try to find the file if exact match doesn't exist
       if vim.fn.filereadable(file_path) == 0 then
-        local find_cmd = "find " .. vim.fn.expand(config.options.vault_path) .. " -name '*" .. link_text .. "*.md' -type f"
+        local find_cmd = "find " .. vim.fn.expand(config.options.vault_path) .. " -name '*" .. link_text .. "*.md' -type f -not -path '*/.*'"
         local found_files = vim.fn.systemlist(find_cmd)
         if #found_files > 0 then
           file_path = found_files[1]

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -41,7 +41,7 @@ function M.find_notes()
   fzf.files({
     prompt = "Find Notes> ",
     cwd = vim.fn.expand(config.options.vault_path),
-    find_opts = "-name '*.md' -type f",
+    find_opts = "-name '*.md' -type f -not -path '*/.*'",
   })
 end
 

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -41,7 +41,7 @@ function M.find_notes()
   fzf.files({
     prompt = "Find Notes> ",
     cwd = vim.fn.expand(config.options.vault_path),
-    find_opts = "-name '*.md' -type f -not -path '*/.*'",
+    cmd = "find . -name '*.md' -type f -not -path '*/.*'",
   })
 end
 

--- a/lua/markdown-notes/templates.lua
+++ b/lua/markdown-notes/templates.lua
@@ -53,7 +53,7 @@ function M.pick_template()
   fzf.files({
     prompt = "Select Template> ",
     cwd = vim.fn.expand(config.options.templates_path),
-    find_opts = "-name '*.md' -type f -not -path '*/.*'",
+    cmd = "find . -name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,
     formatter = nil,

--- a/lua/markdown-notes/templates.lua
+++ b/lua/markdown-notes/templates.lua
@@ -53,7 +53,7 @@ function M.pick_template()
   fzf.files({
     prompt = "Select Template> ",
     cwd = vim.fn.expand(config.options.templates_path),
-    find_opts = "-name '*.md' -type f",
+    find_opts = "-name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,
     formatter = nil,


### PR DESCRIPTION
- Add -not -path '*/.*' to all find commands
- Prevents .git, .obsidian, and other hidden directories from appearing in file pickers
- Affects link search, template picker, note finder, and link following functionality