### PR TITLE
Fix template picker './' prefix display

### DIFF
--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -95,7 +95,7 @@ function M.create_from_template()
   fzf.files({
     prompt = "Select Template> ",
     cwd = vim.fn.expand(config.options.templates_path),
-    cmd = "find . -name '*.md' -type f -not -path '*/.*'",
+    cmd = "find . -name '*.md' -type f -not -path '*/.*' -printf '%P\\n'",
     file_icons = false,
     path_shorten = false,
     formatter = nil,


### PR DESCRIPTION
## Summary
- Fixes template picker showing './template-name.md' instead of 'template-name.md'
- Added -printf '%P\n' to find command to display clean relative paths

## Type
Bug fix - patch release candidate for v1.0.1

## Test plan
- [x] Test template picker displays clean filenames without './' prefix
- [x] Verify template selection still works correctly
- [x] Confirm no regression in template functionality