### PR TITLE
feat: add workspace system for multi-vault note management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple, configurable markdown note-taking plugin for Neovim with support for d
 - **Wiki-style Links**: Create and follow `[[note-name]]` links between notes
 - **Powerful Search**: Find notes by filename or content, search frontmatter tags with syntax highlighting
 - **Backlinks**: Discover which notes reference the current note
+- **Workspaces**: Support for multiple independent note vaults with manual switching
 - **Configurable**: Customize paths, keybindings, and behavior
 
 ## Requirements
@@ -89,6 +90,112 @@ require("markdown-notes").setup({
 })
 ```
 
+## Workspaces
+
+Workspaces allow you to manage multiple independent note vaults simultaneously. Each workspace has its own configuration for paths, templates, and settings. You can set a default workspace and manually switch between them as needed.
+
+### Workspace Setup
+
+```lua
+-- Basic plugin setup with default workspace
+require("markdown-notes").setup({
+  vault_path = "~/notes",
+  templates_path = "~/notes/templates",
+  default_workspace = "personal", -- Optional: specify which workspace to use by default
+})
+
+-- Set up work workspace
+require("markdown-notes").setup_workspace("work", {
+  vault_path = "~/work-notes",
+  templates_path = "~/work-notes/templates",
+  dailies_path = "~/work-notes/dailies",
+  notes_subdir = "projects",
+  default_template = "work-note",
+  template_vars = {
+    -- Custom variables for work notes
+    project = function() return "Current Project" end,
+  },
+})
+
+-- Set up personal workspace
+require("markdown-notes").setup_workspace("personal", {
+  vault_path = "~/personal-notes",
+  templates_path = "~/personal-notes/templates", 
+  dailies_path = "~/personal-notes/journal",
+  notes_subdir = "thoughts",
+  default_template = "personal-note",
+})
+```
+
+### Workspace Behavior
+
+The plugin uses a simple, predictable workspace system:
+
+- **Default workspace**: Set via `default_workspace` in config, or first workspace configured becomes default
+- **Manual switching**: Use `<leader>ow` or commands to switch active workspace  
+- **Persistent**: All operations use the active workspace until you manually switch
+
+### Workspace Management Commands
+
+- `:MarkdownNotesWorkspaceStatus` - Show current workspace for the buffer
+- `:MarkdownNotesWorkspacePick` - Pick workspace with fuzzy finder
+- `:MarkdownNotesWorkspaceSwitch <name>` - Switch to a workspace directory
+
+### Multi-Vault Workflow
+
+With workspaces, you can:
+
+1. **Work on multiple projects simultaneously**: Have work notes open in one split and personal notes in another
+2. **Context-specific templates**: Use different templates for work vs personal notes
+3. **Separate organization**: Each workspace maintains its own directory structure and settings
+4. **Seamless switching**: All plugin commands automatically use the correct workspace configuration
+
+### Example Multi-Workspace Setup
+
+```lua
+-- ~/.config/nvim/lua/config/notes.lua
+local notes = require("markdown-notes")
+
+-- Base configuration
+notes.setup({
+  vault_path = "~/notes",
+  templates_path = "~/notes/templates",
+})
+
+-- Work workspace
+notes.setup_workspace("work", {
+  vault_path = "~/work/knowledge-base",
+  templates_path = "~/work/knowledge-base/templates",
+  dailies_path = "~/work/knowledge-base/daily-standups",
+  notes_subdir = "projects",
+  default_template = "work-note",
+  template_vars = {
+    sprint = function() return "Sprint-" .. os.date("%U") end,
+    standup_date = function() return os.date("%A, %B %d") end,
+  },
+})
+
+-- Research workspace  
+notes.setup_workspace("research", {
+  vault_path = "~/research/papers",
+  templates_path = "~/research/templates",
+  dailies_path = "~/research/lab-notes",
+  notes_subdir = "literature",
+  default_template = "research-paper",
+  template_vars = {
+    citation = function() return "[@author" .. os.date("%Y") .. "]" end,
+  },
+})
+
+-- Personal workspace
+notes.setup_workspace("personal", {
+  vault_path = "~/personal/journal",
+  templates_path = "~/personal/templates",
+  dailies_path = "~/personal/daily",
+  default_template = "journal-entry",
+})
+```
+
 ## Usage
 
 ### Daily Notes
@@ -125,6 +232,7 @@ Daily notes are automatically created with your `Daily.md` template if it exists
 ### Tags
 
 - `<leader>og` - Search for tags from frontmatter (YAML tags: [tag1, tag2])
+- `<leader>ow` - Pick workspace with fuzzy finder
   - Shows tag list with file counts
   - Select a tag to view files containing that tag with preview
 

--- a/doc/markdown-notes.txt
+++ b/doc/markdown-notes.txt
@@ -7,14 +7,15 @@ CONTENTS                                                *markdown-notes-contents
 2. Requirements                                      |markdown-notes-requirements|
 3. Installation                                      |markdown-notes-installation|
 4. Configuration                                     |markdown-notes-configuration|
-5. Usage                                             |markdown-notes-usage|
-6. Commands                                          |markdown-notes-commands|
-7. Note Naming                                       |markdown-notes-note-naming|
-8. Template Variables                                |markdown-notes-template-vars|
-9. Directory Structure                               |markdown-notes-directory|
-10. Link Formats                                     |markdown-notes-link-formats|
-11. Troubleshooting                                  |markdown-notes-troubleshooting|
-12. API                                              |markdown-notes-api|
+5. Workspaces                                        |markdown-notes-workspaces|
+6. Usage                                             |markdown-notes-usage|
+7. Commands                                          |markdown-notes-commands|
+8. Note Naming                                       |markdown-notes-note-naming|
+9. Template Variables                                |markdown-notes-template-vars|
+10. Directory Structure                              |markdown-notes-directory|
+11. Link Formats                                     |markdown-notes-link-formats|
+12. Troubleshooting                                  |markdown-notes-troubleshooting|
+13. API                                              |markdown-notes-api|
 
 ==============================================================================
 INTRODUCTION                                        *markdown-notes-introduction*
@@ -30,6 +31,7 @@ Features:
 - Wiki-style Links: Create and follow `[[note-name]]` links between notes
 - Powerful Search: Find notes by filename or content, search tags
 - Backlinks: Discover which notes reference the current note
+- Workspaces: Support for multiple independent note vaults with manual switching
 - Configurable: Customize paths, keybindings, and behavior
 
 ==============================================================================
@@ -142,6 +144,80 @@ mappings~
     Table of key mappings (see |markdown-notes-commands|).
 
 ==============================================================================
+WORKSPACES                                              *markdown-notes-workspaces*
+
+Workspaces allow you to manage multiple independent note vaults simultaneously. 
+Each workspace has its own configuration for paths, templates, and settings. 
+You can set a default workspace and manually switch between them as needed.
+
+Workspace Setup~
+                                               *markdown-notes-workspace-setup*
+Basic workspace configuration: >
+    -- Basic plugin setup
+    require("markdown-notes").setup({
+      -- Default configuration (fallback when no workspace is detected)
+      vault_path = "~/default-notes",
+      templates_path = "~/default-notes/templates",
+    })
+    
+    -- Set up work workspace
+    require("markdown-notes").setup_workspace("work", {
+      vault_path = "~/work-notes",
+      templates_path = "~/work-notes/templates",
+      dailies_path = "~/work-notes/dailies",
+      notes_subdir = "projects",
+      default_template = "work-note",
+      template_vars = {
+        project = function() return "Current Project" end,
+      },
+    })
+    
+    -- Set up personal workspace
+    require("markdown-notes").setup_workspace("personal", {
+      vault_path = "~/personal-notes",
+      templates_path = "~/personal-notes/templates",
+      dailies_path = "~/personal-notes/journal",
+      notes_subdir = "thoughts",
+      default_template = "personal-note",
+    })
+<
+
+Workspace Behavior~
+                                          *markdown-notes-workspace-behavior*
+The plugin uses a simple, predictable workspace system:
+
+- **Default workspace**: Set via `default_workspace` in config, or first workspace configured becomes default
+- **Manual switching**: Use `<leader>ow` or commands to switch active workspace  
+- **Persistent**: All operations use the active workspace until you manually switch
+
+All plugin commands use the currently active workspace configuration.
+
+Workspace Management Commands~
+                                           *markdown-notes-workspace-commands*
+The following commands are available for workspace management:
+
+:MarkdownNotesWorkspaceStatus                 *:MarkdownNotesWorkspaceStatus*
+    Show current workspace for the buffer
+
+:MarkdownNotesWorkspacePick                   *:MarkdownNotesWorkspacePick*
+    Pick workspace with fuzzy finder
+
+:MarkdownNotesWorkspaceSwitch {name}          *:MarkdownNotesWorkspaceSwitch*
+    Switch to a workspace directory. Tab completion available.
+
+Multi-Vault Workflow~
+                                            *markdown-notes-multi-vault-workflow*
+With workspaces, you can:
+
+1. Work on multiple projects simultaneously: Have work notes open in one split 
+   and personal notes in another
+2. Context-specific templates: Use different templates for work vs personal notes
+3. Separate organization: Each workspace maintains its own directory structure 
+   and settings
+4. Consistent behavior: All plugin commands use the active workspace 
+   configuration
+
+==============================================================================
 USAGE                                                      *markdown-notes-usage*
 
 Daily Notes~
@@ -179,6 +255,7 @@ Templates~
 Tags~
                                                            *markdown-notes-tags*
 - `<leader>og` - Search for tags in frontmatter (YAML format: `tags: [tag1, tag2]`)
+- `<leader>ow` - Pick workspace with fuzzy finder
   - Shows tag list with file counts
   - Select a tag to view files containing that tag with preview
 
@@ -398,6 +475,11 @@ require("markdown-notes").setup({opts})
     Setup function to configure the plugin. See |markdown-notes-configuration|
     for available options.
 
+                                                *markdown-notes.setup_workspace*
+require("markdown-notes").setup_workspace(name, {opts})
+    Setup a workspace with the given name and configuration options. See 
+    |markdown-notes-workspaces| for details and examples.
+
 The plugin exposes the following modules:
 
                                                   *markdown-notes.config*
@@ -419,6 +501,10 @@ require("markdown-notes.links")
                                                *markdown-notes.templates*
 require("markdown-notes.templates")
     Template system and variable substitution.
+
+                                               *markdown-notes.workspace*
+require("markdown-notes.workspace")
+    Workspace management and switching functionality.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/markdown-notes/daily.lua
+++ b/lua/markdown-notes/daily.lua
@@ -6,7 +6,8 @@ local M = {}
 function M.open_daily_note(offset)
   offset = offset or 0
   local date = os.date("%Y-%m-%d", os.time() + (offset * 86400))
-  local file_path = vim.fn.expand(config.options.dailies_path .. "/" .. date .. ".md")
+  local options = config.get_current_config()
+  local file_path = vim.fn.expand(options.dailies_path .. "/" .. date .. ".md")
   
   -- Create directory if it doesn't exist
   local dir = vim.fn.fnamemodify(file_path, ":h")
@@ -16,7 +17,7 @@ function M.open_daily_note(offset)
   
   -- Create file with template if it doesn't exist
   if vim.fn.filereadable(file_path) == 0 then
-    local template_path = vim.fn.expand(config.options.templates_path .. "/Daily.md")
+    local template_path = vim.fn.expand(options.templates_path .. "/Daily.md")
     if vim.fn.filereadable(template_path) == 1 then
       local template_content = vim.fn.readfile(template_path)
       local custom_vars = {

--- a/lua/markdown-notes/links.lua
+++ b/lua/markdown-notes/links.lua
@@ -22,10 +22,11 @@ function M.search_and_link()
     vim.notify("fzf-lua not available", vim.log.levels.ERROR)
     return
   end
+  local options = config.get_current_config()
   
   fzf.files({
     prompt = "Link to Note> ",
-    cwd = vim.fn.expand(config.options.vault_path),
+    cwd = vim.fn.expand(options.vault_path),
     cmd = "find . -name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,
@@ -34,7 +35,7 @@ function M.search_and_link()
     actions = {
       ["default"] = function(selected)
         if selected and #selected > 0 then
-          local file_path = vim.fn.expand(config.options.vault_path .. "/" .. selected[1])
+          local file_path = vim.fn.expand(options.vault_path .. "/" .. selected[1])
           vim.cmd("edit " .. vim.fn.fnameescape(file_path))
         end
       end,
@@ -50,6 +51,7 @@ end
 function M.follow_link()
   local line = vim.api.nvim_get_current_line()
   local col = vim.api.nvim_win_get_cursor(0)[2]
+  local options = config.get_current_config()
   
   -- Look for [[link]] pattern around cursor
   local link_start = line:sub(1, col + 1):find("%[%[[^%]]*$")
@@ -57,11 +59,11 @@ function M.follow_link()
     local link_end = line:find("%]%]", col + 1)
     if link_end then
       local link_text = line:sub(link_start + 2, link_end - 1)
-      local file_path = vim.fn.expand(config.options.vault_path .. "/" .. link_text .. ".md")
+      local file_path = vim.fn.expand(options.vault_path .. "/" .. link_text .. ".md")
       
       -- Try to find the file if exact match doesn't exist
       if vim.fn.filereadable(file_path) == 0 then
-        local find_cmd = "find " .. vim.fn.expand(config.options.vault_path) .. " -name '*" .. link_text .. "*.md' -type f -not -path '*/.*'"
+        local find_cmd = "find " .. vim.fn.expand(options.vault_path) .. " -name '*" .. link_text .. "*.md' -type f -not -path '*/.*'"
         local found_files = vim.fn.systemlist(find_cmd)
         if #found_files > 0 then
           file_path = found_files[1]
@@ -83,7 +85,8 @@ end
 
 function M.show_backlinks()
   local current_path = vim.fn.expand("%:p")
-  local vault_path = vim.fn.expand(config.options.vault_path)
+  local options = config.get_current_config()
+  local vault_path = vim.fn.expand(options.vault_path)
   
   -- Get relative path from vault root and remove .md extension
   local relative_path = current_path:gsub("^" .. vim.pesc(vault_path) .. "/", ""):gsub("%.md$", "")
@@ -136,7 +139,7 @@ function M.show_backlinks()
     actions = {
       ["default"] = function(selected)
         if selected and #selected > 0 then
-          local file_path = vim.fn.expand(config.options.vault_path .. "/" .. selected[1])
+          local file_path = vim.fn.expand(options.vault_path .. "/" .. selected[1])
           vim.cmd("edit " .. vim.fn.fnameescape(file_path))
         end
       end,

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -5,6 +5,7 @@ local M = {}
 
 function M.create_new_note()
   local title = vim.fn.input("Note title (optional): ")
+  local options = config.get_current_config()
   
   -- Generate timestamp-based filename
   local timestamp = tostring(os.time())
@@ -14,7 +15,7 @@ function M.create_new_note()
     filename = timestamp .. "-" .. clean_title
   end
   
-  local file_path = vim.fn.expand(config.options.vault_path .. "/" .. config.options.notes_subdir .. "/" .. filename .. ".md")
+  local file_path = vim.fn.expand(options.vault_path .. "/" .. options.notes_subdir .. "/" .. filename .. ".md")
   
   -- Create directory if needed
   local dir = vim.fn.fnamemodify(file_path, ":h")
@@ -27,12 +28,12 @@ function M.create_new_note()
   local display_title = title ~= "" and title or "Untitled"
   
   -- Use default template if configured, otherwise use basic frontmatter
-  if config.options.default_template then
+  if options.default_template then
     local custom_vars = {
       title = display_title,
       note_title = display_title,
     }
-    if not templates.apply_template_to_file(config.options.default_template, custom_vars) then
+    if not templates.apply_template_to_file(options.default_template, custom_vars) then
       -- Fall back to basic frontmatter if template fails
       local frontmatter = {
         "---",
@@ -64,6 +65,7 @@ end
 
 function M.create_from_template()
   local title = vim.fn.input("Note title (optional): ")
+  local options = config.get_current_config()
   
   -- Generate timestamp-based filename
   local timestamp = tostring(os.time())
@@ -73,7 +75,7 @@ function M.create_from_template()
     filename = timestamp .. "-" .. clean_title
   end
   
-  local file_path = vim.fn.expand(config.options.vault_path .. "/" .. config.options.notes_subdir .. "/" .. filename .. ".md")
+  local file_path = vim.fn.expand(options.vault_path .. "/" .. options.notes_subdir .. "/" .. filename .. ".md")
   
   -- Create directory if needed
   local dir = vim.fn.fnamemodify(file_path, ":h")
@@ -94,7 +96,7 @@ function M.create_from_template()
   
   fzf.files({
     prompt = "Select Template> ",
-    cwd = vim.fn.expand(config.options.templates_path),
+    cwd = vim.fn.expand(options.templates_path),
     cmd = "find . -name '*.md' -type f -not -path '*/.*' -printf '%P\\n'",
     file_icons = false,
     path_shorten = false,
@@ -121,10 +123,11 @@ function M.find_notes()
     vim.notify("fzf-lua not available", vim.log.levels.ERROR)
     return
   end
+  local options = config.get_current_config()
   
   fzf.files({
     prompt = "Find Notes> ",
-    cwd = vim.fn.expand(config.options.vault_path),
+    cwd = vim.fn.expand(options.vault_path),
     cmd = "find . -name '*.md' -type f -not -path '*/.*' -printf '%P\\n'",
     previewer = "builtin",
   })
@@ -136,10 +139,11 @@ function M.search_notes()
     vim.notify("fzf-lua not available", vim.log.levels.ERROR)
     return
   end
+  local options = config.get_current_config()
   
   fzf.grep({
     prompt = "Search Notes> ",
-    cwd = vim.fn.expand(config.options.vault_path),
+    cwd = vim.fn.expand(options.vault_path),
     previewer = "builtin",
   })
 end
@@ -150,8 +154,9 @@ function M.search_tags()
     vim.notify("fzf-lua not available", vim.log.levels.ERROR)
     return
   end
+  local options = config.get_current_config()
   
-  local vault_path = vim.fn.expand(config.options.vault_path)
+  local vault_path = vim.fn.expand(options.vault_path)
   
   -- Get all markdown files
   local find_cmd = "find " .. vim.fn.shellescape(vault_path) .. " -name '*.md' -type f -not -path '*/.*'"

--- a/lua/markdown-notes/templates.lua
+++ b/lua/markdown-notes/templates.lua
@@ -3,7 +3,12 @@ local config = require("markdown-notes.config")
 local M = {}
 
 function M.substitute_template_vars(content, custom_vars)
-  local template_vars = config.options.template_vars or config.defaults.template_vars
+  local options = config.get_current_config()
+  -- Fallback to config.options if no workspace config available
+  if not options then
+    options = config.options
+  end
+  local template_vars = options.template_vars or config.defaults.template_vars
   local vars = {}
   
   -- Manual merge since vim.tbl_extend might not be available in tests
@@ -29,7 +34,11 @@ function M.substitute_template_vars(content, custom_vars)
 end
 
 function M.insert_template(template_name, custom_vars)
-  local template_path = vim.fn.expand(config.options.templates_path .. "/" .. template_name .. ".md")
+  local options = config.get_current_config()
+  if not options then
+    options = config.options
+  end
+  local template_path = vim.fn.expand(options.templates_path .. "/" .. template_name .. ".md")
   
   if vim.fn.filereadable(template_path) == 0 then
     vim.notify("Template not found: " .. template_path, vim.log.levels.ERROR)
@@ -44,7 +53,11 @@ function M.insert_template(template_name, custom_vars)
 end
 
 function M.apply_template_to_file(template_name, custom_vars)
-  local template_path = vim.fn.expand(config.options.templates_path .. "/" .. template_name .. ".md")
+  local options = config.get_current_config()
+  if not options then
+    options = config.options
+  end
+  local template_path = vim.fn.expand(options.templates_path .. "/" .. template_name .. ".md")
   
   if vim.fn.filereadable(template_path) == 0 then
     vim.notify("Template not found: " .. template_path, vim.log.levels.ERROR)
@@ -65,10 +78,14 @@ function M.pick_template()
     vim.notify("fzf-lua not available", vim.log.levels.ERROR)
     return
   end
+  local options = config.get_current_config()
+  if not options then
+    options = config.options
+  end
   
   fzf.files({
     prompt = "Select Template> ",
-    cwd = vim.fn.expand(config.options.templates_path),
+    cwd = vim.fn.expand(options.templates_path),
     cmd = "find . -name '*.md' -type f -not -path '*/.*'",
     file_icons = false,
     path_shorten = false,

--- a/lua/markdown-notes/workspace.lua
+++ b/lua/markdown-notes/workspace.lua
@@ -1,0 +1,95 @@
+local config = require("markdown-notes.config")
+
+local M = {}
+
+
+function M.show_current_workspace()
+  local options, current_workspace = config.get_current_config()
+  local default_workspace = config.get_default_workspace()
+  
+  if current_workspace then
+    local default_indicator = (current_workspace == default_workspace) and " (default)" or ""
+    vim.notify("Current workspace: " .. current_workspace .. default_indicator .. " (" .. options.vault_path .. ")", vim.log.levels.INFO)
+  else
+    vim.notify("Using fallback configuration (no workspace detected)", vim.log.levels.INFO)
+  end
+end
+
+function M.set_default_workspace(workspace_name)
+  if config.set_default_workspace(workspace_name) then
+    vim.notify("Set default workspace to: " .. workspace_name, vim.log.levels.INFO)
+  end
+end
+
+function M.set_active_workspace(workspace_name)
+  if config.set_active_workspace(workspace_name) then
+    local workspace = config.get_workspaces()[workspace_name]
+    local vault_path = vim.fn.expand(workspace.vault_path)
+    vim.cmd("cd " .. vim.fn.fnameescape(vault_path))
+    vim.notify("Switched to workspace: " .. workspace_name, vim.log.levels.INFO)
+  end
+end
+
+function M.show_default_workspace()
+  local default_workspace = config.get_default_workspace()
+  if default_workspace then
+    vim.notify("Default workspace: " .. default_workspace, vim.log.levels.INFO)
+  else
+    vim.notify("No default workspace set", vim.log.levels.INFO)
+  end
+end
+
+function M.switch_to_workspace(workspace_name)
+  local workspaces = config.get_workspaces()
+  
+  if not workspaces[workspace_name] then
+    vim.notify("Workspace '" .. workspace_name .. "' not found", vim.log.levels.ERROR)
+    return
+  end
+  
+  local workspace = workspaces[workspace_name]
+  local vault_path = vim.fn.expand(workspace.vault_path)
+  
+  if vim.fn.isdirectory(vault_path) == 0 then
+    vim.notify("Workspace directory does not exist: " .. vault_path, vim.log.levels.ERROR)
+    return
+  end
+  
+  -- Set as active workspace and change directory
+  M.set_active_workspace(workspace_name)
+end
+
+function M.pick_workspace()
+  local workspaces = config.get_workspaces()
+  
+  if vim.tbl_isempty(workspaces) then
+    vim.notify("No workspaces configured", vim.log.levels.INFO)
+    return
+  end
+  
+  local ok, fzf = pcall(require, "fzf-lua")
+  if not ok then
+    vim.notify("fzf-lua not available", vim.log.levels.ERROR)
+    return
+  end
+  
+  local workspace_list = {}
+  for name, workspace in pairs(workspaces) do
+    table.insert(workspace_list, name .. " - " .. workspace.vault_path)
+  end
+  
+  fzf.fzf_exec(workspace_list, {
+    prompt = "Select Workspace> ",
+    actions = {
+      ["default"] = function(selected)
+        if selected and #selected > 0 then
+          local workspace_name = selected[1]:match("^([^%-]+)")
+          workspace_name = workspace_name:gsub("%s+$", "") -- trim trailing whitespace
+          M.switch_to_workspace(workspace_name)
+        end
+      end,
+    },
+  })
+end
+
+return M

--- a/tests/markdown-notes/config_spec.lua
+++ b/tests/markdown-notes/config_spec.lua
@@ -3,6 +3,9 @@ local config = require("markdown-notes.config")
 describe("config", function()
   before_each(function()
     config.options = {}
+    config.workspaces = {}
+    config.default_workspace = nil
+    config.current_active_workspace = nil
   end)
 
   it("has default configuration", function()
@@ -37,5 +40,180 @@ describe("config", function()
     
     assert.are.equal("<leader>dt", config.options.mappings.daily_note_today)
     assert.is_not_nil(config.options.mappings.new_note)
+  end)
+
+  describe("workspaces", function()
+    it("sets up workspace with custom config", function()
+      local workspace_opts = {
+        vault_path = "/work/notes",
+        templates_path = "/work/templates"
+      }
+      
+      config.setup_workspace("work", workspace_opts)
+      
+      assert.is_not_nil(config.workspaces.work)
+      assert.are.equal("/work/notes", config.workspaces.work.vault_path)
+      assert.are.equal("/work/templates", config.workspaces.work.templates_path)
+      assert.is_not_nil(config.workspaces.work.dailies_path) -- Should inherit from defaults
+    end)
+
+    it("merges workspace config with defaults", function()
+      local workspace_opts = {
+        vault_path = "/personal/notes"
+      }
+      
+      config.setup_workspace("personal", workspace_opts)
+      
+      assert.are.equal("/personal/notes", config.workspaces.personal.vault_path)
+      assert.is_not_nil(config.workspaces.personal.templates_path)
+      assert.is_not_nil(config.workspaces.personal.template_vars)
+      assert.is_not_nil(config.workspaces.personal.mappings)
+    end)
+
+    it("returns workspace list", function()
+      config.setup_workspace("work", { vault_path = "/work" })
+      config.setup_workspace("personal", { vault_path = "/personal" })
+      
+      local workspaces = config.get_workspaces()
+      
+      assert.is_not_nil(workspaces.work)
+      assert.is_not_nil(workspaces.personal)
+      assert.are.equal("/work", workspaces.work.vault_path)
+      assert.are.equal("/personal", workspaces.personal.vault_path)
+    end)
+  end)
+
+  describe("workspace detection", function()
+    before_each(function()
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      config.setup_workspace("personal", { vault_path = "/personal/notes" })
+      -- Set work as default to match expected behavior
+      config.set_default_workspace("work")
+    end)
+
+    it("uses first workspace as active workspace", function()
+      -- With simplified system, first workspace configured becomes active
+      local workspace_config, workspace_name = config.get_current_config()
+      
+      -- "work" is set up first in before_each, so it becomes the active workspace
+      assert.are.equal("work", workspace_name)
+      assert.are.equal("/work/notes", workspace_config.vault_path)
+    end)
+
+
+    it("handles empty buffer name by using active workspace", function()
+      -- No need to mock buffer name - simplified system doesn't depend on it
+      local workspace_config, workspace_name = config.get_current_config()
+      
+      -- Should use the first workspace (work) that was set up in before_each
+      assert.are.equal("work", workspace_name)
+      assert.are.equal("/work/notes", workspace_config.vault_path)
+    end)
+  end)
+
+  describe("default workspace", function()
+    before_each(function()
+      config.setup({ vault_path = "/fallback/notes" })
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      config.setup_workspace("personal", { vault_path = "/personal/notes" })
+    end)
+
+    it("sets and gets default workspace", function()
+      local success = config.set_default_workspace("work")
+      
+      assert.is_true(success)
+      assert.are.equal("work", config.get_default_workspace())
+    end)
+
+    it("fails to set non-existent workspace as default", function()
+      local success = config.set_default_workspace("nonexistent")
+      
+      assert.is_false(success)
+      assert.is_nil(config.get_default_workspace())
+    end)
+
+    it("sets default workspace from main config", function()
+      -- Reset state
+      config.options = {}
+      config.workspaces = {}
+      config.default_workspace = nil
+      config.current_active_workspace = nil
+      
+      -- Setup with default_workspace in config
+      config.setup({
+        vault_path = "/base/notes",
+        default_workspace = "personal"
+      })
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      config.setup_workspace("personal", { vault_path = "/personal/notes" })
+      
+      assert.are.equal("personal", config.get_default_workspace())
+      
+      -- Should use personal workspace as active workspace
+      local workspace_config, workspace_name = config.get_current_config()
+      assert.are.equal("personal", workspace_name)
+      assert.are.equal("/personal/notes", workspace_config.vault_path)
+    end)
+
+    it("first workspace becomes default when no default_workspace specified", function()
+      -- Reset state
+      config.options = {}
+      config.workspaces = {}
+      config.default_workspace = nil
+      config.current_active_workspace = nil
+      
+      -- Setup without default_workspace in config
+      config.setup({ vault_path = "/base/notes" })
+      
+      -- First workspace should become default (via init.lua logic)
+      local init = require("markdown-notes.init")
+      init.setup_workspace("work", { vault_path = "/work/notes" })
+      init.setup_workspace("personal", { vault_path = "/personal/notes" })
+      
+      assert.are.equal("work", config.get_default_workspace())
+      
+      -- Should use work workspace as active workspace
+      local workspace_config, workspace_name = config.get_current_config()
+      assert.are.equal("work", workspace_name)
+      assert.are.equal("/work/notes", workspace_config.vault_path)
+    end)
+
+    it("uses default workspace for empty buffer paths", function()
+      config.set_default_workspace("personal")
+      
+      -- Mock vim.api.nvim_buf_get_name to return empty string
+      local original_get_name = vim.api.nvim_buf_get_name
+      vim.api.nvim_buf_get_name = function(bufnr)
+        return ""
+      end
+
+      local workspace_config, workspace_name = config.get_current_config()
+      
+      assert.are.equal("personal", workspace_name)
+      assert.are.equal("/personal/notes", workspace_config.vault_path)
+      
+      -- Restore original function
+      vim.api.nvim_buf_get_name = original_get_name
+    end)
+
+    it("uses default workspace when no path matches", function()
+      config.set_default_workspace("work")
+      
+      -- Mock vim.api.nvim_buf_get_name to return non-matching path
+      local original_get_name = vim.api.nvim_buf_get_name
+      vim.api.nvim_buf_get_name = function(bufnr)
+        return "/random/location/file.md"
+      end
+
+      local workspace_config, workspace_name = config.get_current_config()
+      
+      assert.are.equal("work", workspace_name)
+      assert.are.equal("/work/notes", workspace_config.vault_path)
+      
+      -- Restore original function
+      vim.api.nvim_buf_get_name = original_get_name
+    end)
+
+
   end)
 end)

--- a/tests/markdown-notes/templates_spec.lua
+++ b/tests/markdown-notes/templates_spec.lua
@@ -3,6 +3,8 @@ local config = require("markdown-notes.config")
 
 describe("templates", function()
   before_each(function()
+    config.options = {}
+    config.workspaces = {}
     config.setup({})
   end)
 

--- a/tests/markdown-notes/workspace_spec.lua
+++ b/tests/markdown-notes/workspace_spec.lua
@@ -1,0 +1,63 @@
+local config = require("markdown-notes.config")
+
+describe("workspace", function()
+  before_each(function()
+    config.options = {}
+    config.workspaces = {}
+    config.default_workspace = nil
+  end)
+
+  describe("workspace configuration", function()
+    it("sets up workspace correctly", function()
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      
+      local workspaces = config.get_workspaces()
+      assert.is_not_nil(workspaces.work)
+      assert.are.equal("/work/notes", workspaces.work.vault_path)
+    end)
+
+    it("sets up multiple workspaces", function()
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      config.setup_workspace("personal", { vault_path = "/personal/notes" })
+      
+      local workspaces = config.get_workspaces()
+      assert.is_not_nil(workspaces.work)
+      assert.is_not_nil(workspaces.personal)
+      assert.are.equal("/work/notes", workspaces.work.vault_path)
+      assert.are.equal("/personal/notes", workspaces.personal.vault_path)
+    end)
+
+    it("workspace inherits from defaults", function()
+      config.setup_workspace("test", { vault_path = "/test" })
+      
+      local workspaces = config.get_workspaces()
+      local test_workspace = workspaces.test
+      
+      assert.are.equal("/test", test_workspace.vault_path)
+      assert.is_not_nil(test_workspace.templates_path)
+      assert.is_not_nil(test_workspace.template_vars)
+      assert.is_not_nil(test_workspace.mappings)
+    end)
+  end)
+
+  describe("workspace detection", function()
+    before_each(function()
+      config.setup({ vault_path = "/default/notes" })
+      config.setup_workspace("work", { vault_path = "/work/notes" })
+      config.setup_workspace("personal", { vault_path = "/personal/notes" })
+      -- Set work as default to match expected behavior
+      config.set_default_workspace("work")
+    end)
+
+    it("uses first workspace as active workspace", function()
+      -- With simplified system, first workspace configured becomes active
+      local workspace_config, workspace_name = config.get_current_config()
+      
+      -- "work" is set up first in before_each, so it becomes the active workspace
+      assert.are.equal("work", workspace_name)
+      assert.are.equal("/work/notes", workspace_config.vault_path)
+    end)
+
+
+  end)
+end)


### PR DESCRIPTION
## Summary

Adds a comprehensive workspace system that allows users to manage multiple independent note vaults simultaneously. Each workspace has its own configuration for paths, templates, and settings with predictable manual switching behavior.

## Key Features

- **Multi-vault support**: Manage separate note collections (work, personal, projects, etc.)
- **Manual workspace switching**: Explicit control via `<leader>ow` keybinding and commands
- **Flexible default workspace**: Set via `default_workspace` config option or auto-default to first workspace
- **Workspace-aware operations**: All plugin functions automatically use the active workspace
- **Fuzzy finder integration**: Interactive workspace selection with fzf-lua

## New Commands

- `:MarkdownNotesWorkspaceStatus` - Show current workspace
- `:MarkdownNotesWorkspacePick` - Interactive workspace picker  
- `:MarkdownNotesWorkspaceSwitch <name>` - Switch to specific workspace
- `:MarkdownNotesWorkspaceActive` - Show active workspace

## New Keybindings

- `<leader>ow` - Pick workspace with fuzzy finder

## Configuration Examples

### Option 1: Set default workspace in config
```lua
require("markdown-notes").setup({
  vault_path = "~/notes",
  default_workspace = "personal", -- Specify default
})

require("markdown-notes").setup_workspace("work", { ... })
require("markdown-notes").setup_workspace("personal", { ... })
```

### Option 2: First workspace becomes default
```lua
require("markdown-notes").setup({ ... })

require("markdown-notes").setup_workspace("personal", { ... }) -- Auto-default
require("markdown-notes").setup_workspace("work", { ... })
```

## Test Plan

- [x] All existing tests pass
- [x] New workspace functionality tests added and passing
- [x] Manual testing confirms workspace switching works correctly
- [x] Documentation updated (README and help docs)
- [x] Keybindings working as expected

## Files Changed

- Core workspace functionality in new `workspace.lua` module
- Updated all core modules to use workspace-aware configuration
- Comprehensive test coverage for workspace features
- Updated documentation and help files