### PR TITLE
Fix: keybinding wrapper function not executing properly

### DIFF
--- a/lua/markdown-notes/init.lua
+++ b/lua/markdown-notes/init.lua
@@ -32,7 +32,7 @@ function M.setup_keymaps()
     -- Use a wrapper that gets current workspace config at runtime
     local function wrapped_cmd()
       if type(cmd) == "function" then
-        return cmd()
+        cmd()
       else
         return cmd
       end


### PR DESCRIPTION
## Summary
- Fixed keybinding wrapper function that was incorrectly returning function results instead of executing them for side effects
- This caused keybindings like `<leader>oy` (yesterday's note) to not work properly

## Test plan
- [x] Verify `<leader>oy` now opens yesterday's note
- [x] Confirm other function-based keybindings still work correctly
- [x] Test that string-based keybindings continue to work as expected

Fixes #13