### PR TITLE
feat!: change default keybinding prefix from <leader>o to <leader>n

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ require("markdown-notes").setup({
   
   -- Key mappings
   mappings = {
-    daily_note_today = "<leader>od",
-    daily_note_yesterday = "<leader>oy", 
-    daily_note_tomorrow = "<leader>ot",
-    new_note = "<leader>on",
-    new_note_from_template = "<leader>oc",
-    find_notes = "<leader>of",
-    search_notes = "<leader>os",
-    insert_link = "<leader>ol",
-    insert_template = "<leader>op",
-    search_tags = "<leader>og",
-    show_backlinks = "<leader>ob",
+    daily_note_today = "<leader>nd",
+    daily_note_yesterday = "<leader>ny", 
+    daily_note_tomorrow = "<leader>nt",
+    new_note = "<leader>nn",
+    new_note_from_template = "<leader>nc",
+    find_notes = "<leader>nf",
+    search_notes = "<leader>ns",
+    insert_link = "<leader>nl",
+    insert_template = "<leader>np",
+    search_tags = "<leader>ng",
+    show_backlinks = "<leader>nb",
     follow_link = "gf",
-    rename_note = "<leader>or",
+    rename_note = "<leader>nr",
   },
 })
 ```
@@ -134,7 +134,7 @@ require("markdown-notes").setup_workspace("personal", {
 The plugin uses a simple, predictable workspace system:
 
 - **Default workspace**: Set via `default_workspace` in config, or first workspace configured becomes default
-- **Manual switching**: Use `<leader>ow` or commands to switch active workspace  
+- **Manual switching**: Use `<leader>nw` or commands to switch active workspace  
 - **Persistent**: All operations use the active workspace until you manually switch
 
 ### Commands
@@ -206,43 +206,43 @@ notes.setup_workspace("personal", {
 
 ### Daily Notes
 
-- `<leader>od` - Open today's daily note
-- `<leader>oy` - Open yesterday's daily note
-- `<leader>ot` - Open tomorrow's daily note
+- `<leader>nd` - Open today's daily note
+- `<leader>ny` - Open yesterday's daily note
+- `<leader>nt` - Open tomorrow's daily note
 
 Daily notes are automatically created with your `Daily.md` template if it exists.
 
 ### Note Management
 
-- `<leader>on` - Create a new note (uses default template if configured, otherwise basic frontmatter)
-- `<leader>oc` - Create a new note from template (choose template interactively)
-- `<leader>of` - Find and open existing notes with file preview
-- `<leader>os` - Search within note contents with syntax highlighting
+- `<leader>nn` - Create a new note (uses default template if configured, otherwise basic frontmatter)
+- `<leader>nc` - Create a new note from template (choose template interactively)
+- `<leader>nf` - Find and open existing notes with file preview
+- `<leader>ns` - Search within note contents with syntax highlighting
 
 ### Links and Navigation
 
-- `<leader>ol` - Search for a note and insert a `[[wiki-link]]`
+- `<leader>nl` - Search for a note and insert a `[[wiki-link]]`
   - Press `Enter` to open the selected note
   - Press `Ctrl+L` to insert a link to the note
 - `gf` - Follow the link under cursor
-- `<leader>ob` - Show backlinks to the current note with file preview
+- `<leader>nb` - Show backlinks to the current note with file preview
   - Press `Enter` to open the selected note
   - Press `Ctrl+L` to insert a link to the note
-- `<leader>or` - Rename the current note and update all references
+- `<leader>nr` - Rename the current note and update all references
   - Prompts for new name and shows confirmation with file count
   - Updates all `[[wiki-links]]` and `[[link|display text]]` references
   - Handles files in subdirectories and prevents partial matches
 
 ### Templates
 
-- `<leader>op` - Insert a template at cursor position with file preview
+- `<leader>np` - Insert a template at cursor position with file preview
 - Templates support variable substitution with `{{variable}}` syntax
 - Configure `default_template` to automatically apply a template to new notes
 
 ### Tags
 
-- `<leader>og` - Search for tags from frontmatter (YAML tags: [tag1, tag2])
-- `<leader>ow` - Pick workspace with fuzzy finder
+- `<leader>ng` - Search for tags from frontmatter (YAML tags: [tag1, tag2])
+- `<leader>nw` - Pick workspace with fuzzy finder
   - Shows tag list with file counts
   - Select a tag to view files containing that tag with preview
 

--- a/doc/markdown-notes.txt
+++ b/doc/markdown-notes.txt
@@ -94,19 +94,19 @@ Default configuration: >
       
       -- Key mappings
       mappings = {
-        daily_note_today = "<leader>od",
-        daily_note_yesterday = "<leader>oy", 
-        daily_note_tomorrow = "<leader>ot",
-        new_note = "<leader>on",
-        new_note_from_template = "<leader>oc",
-        find_notes = "<leader>of",
-        search_notes = "<leader>os",
-        insert_link = "<leader>ol",
-        insert_template = "<leader>op",
-        search_tags = "<leader>og",
-        show_backlinks = "<leader>ob",
+        daily_note_today = "<leader>nd",
+        daily_note_yesterday = "<leader>ny", 
+        daily_note_tomorrow = "<leader>nt",
+        new_note = "<leader>nn",
+        new_note_from_template = "<leader>nc",
+        find_notes = "<leader>nf",
+        search_notes = "<leader>ns",
+        insert_link = "<leader>nl",
+        insert_template = "<leader>np",
+        search_tags = "<leader>ng",
+        show_backlinks = "<leader>nb",
         follow_link = "gf",
-        rename_note = "<leader>or",
+        rename_note = "<leader>nr",
       },
     })
 <
@@ -189,7 +189,7 @@ Workspace Behavior~
 The plugin uses a simple, predictable workspace system:
 
 - **Default workspace**: Set via `default_workspace` in config, or first workspace configured becomes default
-- **Manual switching**: Use `<leader>ow` or commands to switch active workspace  
+- **Manual switching**: Use `<leader>nw` or commands to switch active workspace  
 - **Persistent**: All operations use the active workspace until you manually switch
 
 All plugin commands use the currently active workspace configuration.
@@ -235,42 +235,42 @@ Daily Notes~
                                                     *markdown-notes-daily-notes*
 Create and navigate daily notes with automatic templating.
 
-- `<leader>od` - Open today's daily note
-- `<leader>oy` - Open yesterday's daily note  
-- `<leader>ot` - Open tomorrow's daily note
+- `<leader>nd` - Open today's daily note
+- `<leader>ny` - Open yesterday's daily note  
+- `<leader>nt` - Open tomorrow's daily note
 
 Daily notes are automatically created with your `Daily.md` template if it exists.
 
 Note Management~
                                                 *markdown-notes-note-management*
-- `<leader>on` - Create a new note (uses default template if configured, otherwise basic frontmatter)
-- `<leader>oc` - Create a new note from template (choose template interactively)
-- `<leader>of` - Find and open existing notes (with file preview and syntax highlighting)
-- `<leader>os` - Search within note contents (with file preview and syntax highlighting)
+- `<leader>nn` - Create a new note (uses default template if configured, otherwise basic frontmatter)
+- `<leader>nc` - Create a new note from template (choose template interactively)
+- `<leader>nf` - Find and open existing notes (with file preview and syntax highlighting)
+- `<leader>ns` - Search within note contents (with file preview and syntax highlighting)
 
 Links and Navigation~
                                                 *markdown-notes-links-navigation*
-- `<leader>ol` - Search for a note and insert a `[[wiki-link]]` (with file preview)
+- `<leader>nl` - Search for a note and insert a `[[wiki-link]]` (with file preview)
   - Press `Enter` to open the selected note
   - Press `Ctrl+L` to insert a link to the note
 - `gf` - Follow the link under cursor (supports fuzzy matching)
-- `<leader>ob` - Show backlinks to the current note (with file preview)
+- `<leader>nb` - Show backlinks to the current note (with file preview)
   - Press `Enter` to open the selected note
   - Press `Ctrl+L` to insert a link to the note
-- `<leader>or` - Rename the current note and update all references
+- `<leader>nr` - Rename the current note and update all references
   - Prompts for new name and shows confirmation with file count
   - Updates all `[[wiki-links]]` and `[[link|display text]]` references
   - Handles files in subdirectories and prevents partial matches
 
 Templates~
                                                       *markdown-notes-templates*
-- `<leader>op` - Insert a template at cursor position (with file preview)
+- `<leader>np` - Insert a template at cursor position (with file preview)
 - Templates support variable substitution with `{{variable}}` syntax
 
 Tags~
                                                            *markdown-notes-tags*
-- `<leader>og` - Search for tags in frontmatter (YAML format: `tags: [tag1, tag2]`)
-- `<leader>ow` - Pick workspace with fuzzy finder
+- `<leader>ng` - Search for tags in frontmatter (YAML format: `tags: [tag1, tag2]`)
+- `<leader>nw` - Pick workspace with fuzzy finder
   - Shows tag list with file counts
   - Select a tag to view files containing that tag with preview
 
@@ -449,7 +449,7 @@ When following links with `gf`, the plugin uses fuzzy matching:
 
 Backlinks Detection~
                                                *markdown-notes-backlinks-detection*
-The backlinks feature (`<leader>ob`) detects both:
+The backlinks feature (`<leader>nb`) detects both:
 - Basic links: `[[current-note]]`
 - Links with display text: `[[current-note|custom text]]`
 

--- a/lua/markdown-notes/config.lua
+++ b/lua/markdown-notes/config.lua
@@ -23,20 +23,20 @@ M.defaults = {
   
   -- Key mappings
   mappings = {
-    daily_note_today = "<leader>od",
-    daily_note_yesterday = "<leader>oy", 
-    daily_note_tomorrow = "<leader>ot",
-    new_note = "<leader>on",
-    new_note_from_template = "<leader>oc",
-    find_notes = "<leader>of",
-    search_notes = "<leader>os",
-    insert_link = "<leader>ol",
-    insert_template = "<leader>op",
-    search_tags = "<leader>og",
-    show_backlinks = "<leader>ob",
+    daily_note_today = "<leader>nd",
+    daily_note_yesterday = "<leader>ny", 
+    daily_note_tomorrow = "<leader>nt",
+    new_note = "<leader>nn",
+    new_note_from_template = "<leader>nc",
+    find_notes = "<leader>nf",
+    search_notes = "<leader>ns",
+    insert_link = "<leader>nl",
+    insert_template = "<leader>np",
+    search_tags = "<leader>ng",
+    show_backlinks = "<leader>nb",
     follow_link = "gf",
-    rename_note = "<leader>or",
-    pick_workspace = "<leader>ow",
+    rename_note = "<leader>nr",
+    pick_workspace = "<leader>nw",
   },
 }
 


### PR DESCRIPTION
## Summary
- Changes all default keybindings from `<leader>o*` prefix to `<leader>n*` for better semantic meaning as a notes plugin
- Updates documentation in README.md and help files
- **BREAKING CHANGE**: Users relying on default keybindings will need to update their muscle memory or configuration

## Changes Made
- Updated all default keybindings in `lua/markdown-notes/config.lua`
- Updated documentation in `README.md` with new keybinding examples
- Updated help documentation in `doc/markdown-notes.txt`

## Migration Guide
Users who prefer the old `<leader>o` prefix can restore it by setting custom mappings:

```lua
require("markdown-notes").setup({
  mappings = {
    daily_note_today = "<leader>od",
    daily_note_yesterday = "<leader>oy",
    daily_note_tomorrow = "<leader>ot",
    new_note = "<leader>on",
    new_note_from_template = "<leader>oc",
    find_notes = "<leader>of",
    search_notes = "<leader>os",
    insert_link = "<leader>ol",
    insert_template = "<leader>op",
    search_tags = "<leader>og",
    show_backlinks = "<leader>ob",
    follow_link = "gf",
    rename_note = "<leader>or",
    pick_workspace = "<leader>ow",
  }
})
```

## Rationale
The `<leader>o` prefix was originally chosen due to familiarity with obsidian.nvim, but `<leader>n` provides better semantic meaning for a notes plugin and is more intuitive for new users.

## Test plan
- [x] Verify all keybindings work with new prefix
- [x] Confirm documentation is updated
- [x] Test that existing functionality remains intact
- [x] Verify users can restore old keybindings via configuration