### PR TITLE
Fix: Link insertion should use paths relative to notes root directory

### DIFF
--- a/lua/markdown-notes/links.lua
+++ b/lua/markdown-notes/links.lua
@@ -4,8 +4,10 @@ local M = {}
 
 -- Helper function to insert a link at cursor position
 local function insert_link_at_cursor(file_path)
+	-- Normalize path by removing leading ./ if present
+	local normalized_path = file_path:gsub("^%./", "")
 	-- Remove .md extension but keep the full path
-	local link_path = file_path:gsub("%.md$", "")
+	local link_path = normalized_path:gsub("%.md$", "")
 	local link = "[[" .. link_path .. "]]"
 
 	-- Insert link at cursor


### PR DESCRIPTION
## Summary
- Fixed link insertion to generate paths relative to vault root directory
- Normalized file paths by removing leading './' prefix before creating wiki-style links
- Ensures consistent linking behavior regardless of current file location

## Test plan
- [x] All existing tests pass
- [x] Manual testing confirms links now generate as `[[note]]` instead of `[[./note]]`
- [x] Links from subfolders correctly reference root-relative paths