### PR TITLE
fix: add symlink support to find commands

### DIFF
--- a/lua/markdown-notes/links.lua
+++ b/lua/markdown-notes/links.lua
@@ -70,7 +70,7 @@ function M.follow_link()
 
 			-- Try to find the file if exact match doesn't exist
 			if vim.fn.filereadable(file_path) == 0 then
-				local find_cmd = "find "
+				local find_cmd = "find -L "
 					.. vim.fn.expand(options.vault_path)
 					.. " -name '*"
 					.. link_text

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -160,8 +160,8 @@ function M.search_tags()
 
 	local vault_path = vim.fn.expand(options.vault_path)
 
-	-- Get all markdown files
-	local find_cmd = "find " .. vim.fn.shellescape(vault_path) ..
+	-- Get all markdown files (-L follows symlinks)
+	local find_cmd = "find -L " .. vim.fn.shellescape(vault_path) ..
 		" -name '*.md' -type f -not -path '*/.*'"
 	local all_files = vim.fn.systemlist(find_cmd)
 


### PR DESCRIPTION
## Summary

- Fixes tag search and link following when vault_path is a symbolic link
- Adds `-L` flag to find commands to follow symlinks
- Resolves "No tags found in frontmatter" error for symlinked vaults

## Problem

The `find` command doesn't follow symbolic links by default. When a user's `vault_path` points to a symlink (e.g., `~/personal/docs/notes` → `~/personal/repos/notes`), the find commands would return 0 files, causing:
- Tag search to show "No tags found in frontmatter"
- Link following fuzzy search to fail

## Solution

Added the `-L` flag to find commands in:
- `search_tags()` in `lua/markdown-notes/notes.lua` (line 164)
- `follow_link()` fuzzy search fallback in `lua/markdown-notes/links.lua` (line 73)

## Testing

Tested with symlinked vault:
- Before: 0 files found, no tags
- After: 328 files found, 112 unique tags from 276 files

## Changes

- `lua/markdown-notes/notes.lua`: Added `-L` to find command in search_tags
- `lua/markdown-notes/links.lua`: Added `-L` to find command in follow_link fallback