### PR TITLE
feat: use title slug for filenames with collision detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ require("markdown-notes").setup({
   
   -- Template settings
   default_template = "basic", -- Auto-apply this template to new notes
+
+  -- Filename behavior
+  -- "none" (default): use title slug only (e.g. my-note.md); opens existing note on collision
+  -- "timestamp": prepend unix timestamp (e.g. 1720094400-my-note.md) for guaranteed uniqueness
+  filename_prefix = "none",
   
   -- UI behavior
   ui = {

--- a/doc/markdown-notes.txt
+++ b/doc/markdown-notes.txt
@@ -245,7 +245,12 @@ Custom Configuration Options~
       
       -- Template settings
       default_template = "basic", -- Auto-apply this template to new notes
-      
+
+      -- Filename behavior
+      -- "none" (default): use title slug only (e.g. my-note.md); opens existing note on collision
+      -- "timestamp": prepend unix timestamp (e.g. 1720094400-my-note.md) for guaranteed uniqueness
+      filename_prefix = "none",
+
       -- UI behavior
       ui = {
         show_rename_preview = true, -- Show file preview when renaming notes with links

--- a/lua/markdown-notes/config.lua
+++ b/lua/markdown-notes/config.lua
@@ -7,6 +7,8 @@ M.defaults = {
 	weekly_path = "~/repos/notes/personal/weekly",
 	notes_subdir = "notes",
 	default_template = nil, -- Optional default template for new notes
+	-- "none": use title slug only; "timestamp": prepend unix timestamp (legacy)
+	filename_prefix = "none",
 
 	-- Template substitution variables
 	template_vars = {

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -3,20 +3,29 @@ local templates = require("markdown-notes.templates")
 
 local M = {}
 
+local function build_filename(title, options)
+	local slug = title ~= "" and title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower() or nil
+	if options.filename_prefix == "timestamp" then
+		local ts = tostring(os.time())
+		return slug and (ts .. "-" .. slug) or ts
+	else
+		return slug or tostring(os.time())
+	end
+end
+
 function M.create_new_note()
 	local title = vim.fn.input("Note title (optional): ")
 	local options = config.get_current_config()
 
-	-- Generate timestamp-based filename
-	local timestamp = tostring(os.time())
-	local filename = timestamp
-	if title ~= "" then
-		local clean_title = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
-		filename = timestamp .. "-" .. clean_title
-	end
-
+	local filename = build_filename(title, options)
 	local file_path = vim.fn.expand(options.vault_path .. "/" ..
 		options.notes_subdir .. "/" .. filename .. ".md")
+
+	if options.filename_prefix ~= "timestamp" and vim.fn.filereadable(file_path) == 1 then
+		vim.notify("Note already exists, opening: " .. filename, vim.log.levels.INFO)
+		vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+		return
+	end
 
 	-- Create directory if needed
 	local dir = vim.fn.fnamemodify(file_path, ":h")
@@ -68,16 +77,15 @@ function M.create_from_template()
 	local title = vim.fn.input("Note title (optional): ")
 	local options = config.get_current_config()
 
-	-- Generate timestamp-based filename
-	local timestamp = tostring(os.time())
-	local filename = timestamp
-	if title ~= "" then
-		local clean_title = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
-		filename = timestamp .. "-" .. clean_title
-	end
-
+	local filename = build_filename(title, options)
 	local file_path = vim.fn.expand(options.vault_path .. "/" ..
 		options.notes_subdir .. "/" .. filename .. ".md")
+
+	if options.filename_prefix ~= "timestamp" and vim.fn.filereadable(file_path) == 1 then
+		vim.notify("Note already exists, opening: " .. filename, vim.log.levels.INFO)
+		vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+		return
+	end
 
 	-- Create directory if needed
 	local dir = vim.fn.fnamemodify(file_path, ":h")

--- a/tests/markdown-notes/notes_spec.lua
+++ b/tests/markdown-notes/notes_spec.lua
@@ -5,6 +5,7 @@ describe("notes", function()
 	before_each(function()
 		config.options = {}
 		config.workspaces = {}
+		config.current_active_workspace = nil
 		config.setup({
 			vault_path = "/tmp/test-vault",
 			notes_subdir = "notes",
@@ -17,63 +18,132 @@ describe("notes", function()
 			assert.are.equal("function", type(notes.create_new_note))
 		end)
 
-		it("generates timestamp-based filename format", function()
-			-- Test the timestamp generation logic by checking it uses os.time
-			local original_os = _G.os
-			local test_timestamp = 1720094400
-			_G.os = setmetatable({
-				time = function()
-					return test_timestamp
-				end,
-			}, { __index = original_os })
-
-			-- Mock vim.fn.input to return empty string (no title)
+		it("uses title slug as filename by default", function()
 			local original_input = vim.fn.input
-			vim.fn.input = function()
-				return ""
-			end
+			vim.fn.input = function() return "My New Note" end
 
-			-- Mock file operations to avoid actual file creation
 			local original_expand = vim.fn.expand
 			vim.fn.expand = function(path)
-				if path:match("^/tmp/test%-vault") then
-					return path
-				end
+				if path:match("^/tmp/test%-vault") then return path end
 				return original_expand(path)
 			end
 
+			local original_filereadable = vim.fn.filereadable
+			vim.fn.filereadable = function() return 0 end
+
 			local original_fnamemodify = vim.fn.fnamemodify
 			vim.fn.fnamemodify = function(path, modifier)
-				if modifier == ":h" then
-					return "/tmp/test-vault/notes"
-				end
+				if modifier == ":h" then return "/tmp/test-vault/notes" end
 				return original_fnamemodify(path, modifier)
 			end
 
 			local original_isdirectory = vim.fn.isdirectory
-			vim.fn.isdirectory = function()
-				return 1
-			end
+			vim.fn.isdirectory = function() return 1 end
 
 			local opened_file = nil
 			local original_cmd = vim.cmd
 			vim.cmd = function(cmd)
-				if cmd:match("^edit ") then
-					opened_file = cmd:match("^edit (.+)$")
-				end
+				if cmd:match("^edit ") then opened_file = cmd:match("^edit (.+)$") end
 			end
 
 			local original_buf_set_lines = vim.api.nvim_buf_set_lines
 			vim.api.nvim_buf_set_lines = function() end
 
-			-- Call the function
 			notes.create_new_note()
 
-			-- Verify timestamp-based filename was used
 			assert.is_not_nil(opened_file)
-			assert.matches(tostring(test_timestamp), opened_file)
+			assert.matches("my%-new%-note%.md$", opened_file)
 
-			-- Restore mocks
+			vim.fn.input = original_input
+			vim.fn.expand = original_expand
+			vim.fn.filereadable = original_filereadable
+			vim.fn.fnamemodify = original_fnamemodify
+			vim.fn.isdirectory = original_isdirectory
+			vim.cmd = original_cmd
+			vim.api.nvim_buf_set_lines = original_buf_set_lines
+		end)
+
+		it("opens existing file instead of creating when slug already exists", function()
+			local original_input = vim.fn.input
+			vim.fn.input = function() return "Existing Note" end
+
+			local original_expand = vim.fn.expand
+			vim.fn.expand = function(path)
+				if path:match("^/tmp/test%-vault") then return path end
+				return original_expand(path)
+			end
+
+			local original_filereadable = vim.fn.filereadable
+			vim.fn.filereadable = function() return 1 end  -- file already exists
+
+			local opened_file = nil
+			local original_cmd = vim.cmd
+			vim.cmd = function(cmd)
+				if cmd:match("^edit ") then opened_file = cmd:match("^edit (.+)$") end
+			end
+
+			local mkdir_called = false
+			local original_mkdir = vim.fn.mkdir
+			vim.fn.mkdir = function() mkdir_called = true end
+
+			notes.create_new_note()
+
+			assert.is_not_nil(opened_file)
+			assert.matches("existing%-note%.md$", opened_file)
+			assert.is_false(mkdir_called)  -- no directory creation for existing file
+
+			vim.fn.input = original_input
+			vim.fn.expand = original_expand
+			vim.fn.filereadable = original_filereadable
+			vim.cmd = original_cmd
+			vim.fn.mkdir = original_mkdir
+		end)
+
+		it("prepends timestamp when filename_prefix is timestamp", function()
+			config.options = {}
+			config.workspaces = {}
+			config.setup({
+				vault_path = "/tmp/test-vault",
+				notes_subdir = "notes",
+				filename_prefix = "timestamp",
+			})
+
+			local original_os = _G.os
+			local test_timestamp = 1720094400
+			_G.os = setmetatable({ time = function() return test_timestamp end }, { __index = original_os })
+
+			local original_input = vim.fn.input
+			vim.fn.input = function() return "My Note" end
+
+			local original_expand = vim.fn.expand
+			vim.fn.expand = function(path)
+				if path:match("^/tmp/test%-vault") then return path end
+				return original_expand(path)
+			end
+
+			local original_fnamemodify = vim.fn.fnamemodify
+			vim.fn.fnamemodify = function(path, modifier)
+				if modifier == ":h" then return "/tmp/test-vault/notes" end
+				return original_fnamemodify(path, modifier)
+			end
+
+			local original_isdirectory = vim.fn.isdirectory
+			vim.fn.isdirectory = function() return 1 end
+
+			local opened_file = nil
+			local original_cmd = vim.cmd
+			vim.cmd = function(cmd)
+				if cmd:match("^edit ") then opened_file = cmd:match("^edit (.+)$") end
+			end
+
+			local original_buf_set_lines = vim.api.nvim_buf_set_lines
+			vim.api.nvim_buf_set_lines = function() end
+
+			notes.create_new_note()
+
+			assert.is_not_nil(opened_file)
+			assert.matches(tostring(test_timestamp) .. "%-my%-note%.md$", opened_file)
+
 			_G.os = original_os
 			vim.fn.input = original_input
 			vim.fn.expand = original_expand


### PR DESCRIPTION
## Summary

- Replace timestamp-prefixed filenames with clean title slugs by default (e.g. `my-note.md` instead of `1720094400-my-note.md`)
- When a note with the same slug already exists, open it instead of creating a duplicate
- Add `filename_prefix` config option: `"none"` (default) for slug-only filenames, `"timestamp"` to restore legacy behavior
- Fix test isolation bug where `current_active_workspace` was not reset between tests

## Test plan

- [ ] Create a new note with a title — verify filename is `title-slug.md` with no timestamp prefix
- [ ] Create a note with the same title again — verify the existing note opens instead of creating a duplicate
- [ ] Set `filename_prefix = "timestamp"` and create a note — verify timestamp is prepended as before
- [ ] Run test suite: `nvim --headless -u tests/minimal_init.vim -c "lua require('plenary.test_harness').test_directory('tests')"`