### PR TITLE
feat: route notes to subdirectories based on template selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,15 @@ require("markdown-notes").setup({
   -- Template settings
   default_template = "basic", -- Auto-apply this template to new notes
 
+  -- Route notes to specific subdirectories based on the template used.
+  -- Key: template name (without .md extension), Value: subdir relative to vault_path.
+  -- Falls back to notes_subdir when no match is found.
+  template_dirs = {
+    ["private"]  = "private",        -- <leader>nc → pick "private"  → vault/private/
+    ["meeting"]  = "work/meetings",  -- <leader>nc → pick "meeting"  → vault/work/meetings/
+    ["journal"]  = "journal",        -- <leader>nc → pick "journal"  → vault/journal/
+  },
+
   -- Filename behavior
   -- "none" (default): use title slug only (e.g. my-note.md); opens existing note on collision
   -- "timestamp": prepend unix timestamp (e.g. 1720094400-my-note.md) for guaranteed uniqueness
@@ -370,18 +379,45 @@ require("markdown-notes").setup_workspace("research", {
 - **Persistent context**: All commands use the active workspace until you switch
 - **Independent settings**: Each workspace has its own paths, templates, and variables
 
+### Template-Based Directory Routing
+
+Use `template_dirs` to automatically place notes in specific subdirectories based on the template chosen with `<leader>nc`. When `default_template` is set, `<leader>nn` respects the same mapping.
+
+```lua
+require("markdown-notes").setup({
+  vault_path = "~/notes",
+  notes_subdir = "notes",        -- default destination
+  default_template = "default",
+  template_dirs = {
+    ["private"]  = "private",        -- stays out of sync/search
+    ["meeting"]  = "work/meetings",
+    ["journal"]  = "journal",
+  },
+})
+```
+
+Directories are created automatically if they don't exist.
+
 ### Directory Structure Example
 
 ```
 ~/notes/                          # Main vault
 ├── templates/                    # Your templates
 │   ├── Daily.md                 # Auto-applied to daily notes
-│   ├── meeting.md               # Meeting template
-│   └── project.md               # Project template
+│   ├── meeting.md               # → work/meetings/
+│   ├── private.md               # → private/
+│   ├── journal.md               # → journal/
+│   └── project.md               # → notes/ (default)
 ├── daily/                       # Daily notes
 │   ├── 2025-01-15.md
 │   └── 2025-01-16.md
-└── notes/                       # Regular notes
+├── private/                     # Private notes (excluded from sync)
+│   └── secret-idea.md
+├── work/meetings/               # Meeting notes
+│   └── team-standup.md
+├── journal/                     # Journal entries
+│   └── 2025-01-15-reflection.md
+└── notes/                       # General notes (default)
     ├── project-ideas.md
     └── learning-resources.md
 ```

--- a/doc/markdown-notes.txt
+++ b/doc/markdown-notes.txt
@@ -246,6 +246,15 @@ Custom Configuration Options~
       -- Template settings
       default_template = "basic", -- Auto-apply this template to new notes
 
+      -- Route notes to specific subdirectories based on the template used.
+      -- Key: template name (without .md), Value: subdir relative to vault_path.
+      -- Falls back to notes_subdir when no match is found.
+      template_dirs = {
+        ["private"]  = "private",
+        ["meeting"]  = "work/meetings",
+        ["journal"]  = "journal",
+      },
+
       -- Filename behavior
       -- "none" (default): use title slug only (e.g. my-note.md); opens existing note on collision
       -- "timestamp": prepend unix timestamp (e.g. 1720094400-my-note.md) for guaranteed uniqueness
@@ -288,18 +297,44 @@ Custom Configuration Options~
     })
 <
 
+Template-Based Directory Routing~
+                                      *markdown-notes-advanced-template-dirs*
+Use `template_dirs` to route notes into specific subdirectories based on the
+template chosen with `<leader>nc`. When `default_template` is set, `<leader>nn`
+respects the same mapping. Directories are created automatically. >
+
+    require("markdown-notes").setup({
+      vault_path = "~/notes",
+      notes_subdir = "notes",        -- default destination
+      default_template = "default",
+      template_dirs = {
+        ["private"]  = "private",        -- stays out of sync/search
+        ["meeting"]  = "work/meetings",
+        ["journal"]  = "journal",
+      },
+    })
+<
+
 Directory Structure Example~
                                         *markdown-notes-advanced-directory-structure*
 >
     ~/notes/                          # Main vault
     ├── templates/                    # Your templates
     │   ├── Daily.md                 # Auto-applied to daily notes
-    │   ├── meeting.md               # Meeting template
-    │   └── project.md               # Project template
+    │   ├── meeting.md               # → work/meetings/
+    │   ├── private.md               # → private/
+    │   ├── journal.md               # → journal/
+    │   └── project.md               # → notes/ (default)
     ├── daily/                       # Daily notes
     │   ├── 2025-01-15.md
     │   └── 2025-01-16.md
-    └── notes/                       # Regular notes
+    ├── private/                     # Private notes
+    │   └── secret-idea.md
+    ├── work/meetings/               # Meeting notes
+    │   └── team-standup.md
+    ├── journal/                     # Journal entries
+    │   └── 2025-01-15-reflection.md
+    └── notes/                       # General notes (default)
         ├── project-ideas.md
         └── learning-resources.md
 <

--- a/doc/tags
+++ b/doc/tags
@@ -6,6 +6,7 @@ markdown-notes	markdown-notes.txt	/*markdown-notes*
 markdown-notes-advanced-config	markdown-notes.txt	/*markdown-notes-advanced-config*
 markdown-notes-advanced-config-opts	markdown-notes.txt	/*markdown-notes-advanced-config-opts*
 markdown-notes-advanced-directory-structure	markdown-notes.txt	/*markdown-notes-advanced-directory-structure*
+markdown-notes-advanced-template-dirs	markdown-notes.txt	/*markdown-notes-advanced-template-dirs*
 markdown-notes-api	markdown-notes.txt	/*markdown-notes-api*
 markdown-notes-basic-config	markdown-notes.txt	/*markdown-notes-basic-config*
 markdown-notes-commands	markdown-notes.txt	/*markdown-notes-commands*

--- a/lua/markdown-notes/config.lua
+++ b/lua/markdown-notes/config.lua
@@ -9,6 +9,8 @@ M.defaults = {
 	default_template = nil, -- Optional default template for new notes
 	-- "none": use title slug only; "timestamp": prepend unix timestamp (legacy)
 	filename_prefix = "none",
+	-- Maps template name -> subdirectory (relative to vault_path) for template-based routing
+	template_dirs = {},
 
 	-- Template substitution variables
 	template_vars = {

--- a/lua/markdown-notes/notes.lua
+++ b/lua/markdown-notes/notes.lua
@@ -3,6 +3,13 @@ local templates = require("markdown-notes.templates")
 
 local M = {}
 
+local function get_subdir(template_name, options)
+	if template_name and options.template_dirs and options.template_dirs[template_name] then
+		return options.template_dirs[template_name]
+	end
+	return options.notes_subdir
+end
+
 local function build_filename(title, options)
 	local slug = title ~= "" and title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower() or nil
 	if options.filename_prefix == "timestamp" then
@@ -17,9 +24,10 @@ function M.create_new_note()
 	local title = vim.fn.input("Note title (optional): ")
 	local options = config.get_current_config()
 
+	local subdir = get_subdir(options.default_template, options)
 	local filename = build_filename(title, options)
 	local file_path = vim.fn.expand(options.vault_path .. "/" ..
-		options.notes_subdir .. "/" .. filename .. ".md")
+		subdir .. "/" .. filename .. ".md")
 
 	if options.filename_prefix ~= "timestamp" and vim.fn.filereadable(file_path) == 1 then
 		vim.notify("Note already exists, opening: " .. filename, vim.log.levels.INFO)
@@ -76,28 +84,8 @@ end
 function M.create_from_template()
 	local title = vim.fn.input("Note title (optional): ")
 	local options = config.get_current_config()
-
-	local filename = build_filename(title, options)
-	local file_path = vim.fn.expand(options.vault_path .. "/" ..
-		options.notes_subdir .. "/" .. filename .. ".md")
-
-	if options.filename_prefix ~= "timestamp" and vim.fn.filereadable(file_path) == 1 then
-		vim.notify("Note already exists, opening: " .. filename, vim.log.levels.INFO)
-		vim.cmd("edit " .. vim.fn.fnameescape(file_path))
-		return
-	end
-
-	-- Create directory if needed
-	local dir = vim.fn.fnamemodify(file_path, ":h")
-	if vim.fn.isdirectory(dir) == 0 then
-		vim.fn.mkdir(dir, "p")
-	end
-
-	vim.cmd("edit " .. file_path)
-
 	local display_title = title ~= "" and title or "Untitled"
 
-	-- Let user pick a template
 	local ok, fzf = pcall(require, "fzf-lua")
 	if not ok then
 		vim.notify("fzf-lua not available", vim.log.levels.ERROR)
@@ -116,6 +104,24 @@ function M.create_from_template()
 			["default"] = function(selected)
 				if selected and #selected > 0 then
 					local template_name = vim.fn.fnamemodify(selected[1], ":t:r")
+					local subdir = get_subdir(template_name, options)
+					local filename = build_filename(title, options)
+					local file_path = vim.fn.expand(options.vault_path .. "/" ..
+						subdir .. "/" .. filename .. ".md")
+
+					if options.filename_prefix ~= "timestamp" and vim.fn.filereadable(file_path) == 1 then
+						vim.notify("Note already exists, opening: " .. filename, vim.log.levels.INFO)
+						vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+						return
+					end
+
+					local dir = vim.fn.fnamemodify(file_path, ":h")
+					if vim.fn.isdirectory(dir) == 0 then
+						vim.fn.mkdir(dir, "p")
+					end
+
+					vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+
 					local custom_vars = {
 						title = display_title,
 						note_title = display_title,

--- a/tests/markdown-notes/notes_spec.lua
+++ b/tests/markdown-notes/notes_spec.lua
@@ -154,6 +154,113 @@ describe("notes", function()
 		end)
 	end)
 
+	describe("template_dirs routing", function()
+		it("uses notes_subdir when no template_dirs configured", function()
+			local original_input = vim.fn.input
+			vim.fn.input = function() return "My Note" end
+
+			local original_expand = vim.fn.expand
+			vim.fn.expand = function(path)
+				if path:match("^/tmp/test%-vault") then return path end
+				return original_expand(path)
+			end
+
+			local original_filereadable = vim.fn.filereadable
+			vim.fn.filereadable = function() return 0 end
+
+			local original_fnamemodify = vim.fn.fnamemodify
+			vim.fn.fnamemodify = function(path, modifier)
+				if modifier == ":h" then return "/tmp/test-vault/notes" end
+				return original_fnamemodify(path, modifier)
+			end
+
+			local original_isdirectory = vim.fn.isdirectory
+			vim.fn.isdirectory = function() return 1 end
+
+			local opened_file = nil
+			local original_cmd = vim.cmd
+			vim.cmd = function(cmd)
+				if cmd:match("^edit ") then opened_file = cmd:match("^edit (.+)$") end
+			end
+
+			local original_buf_set_lines = vim.api.nvim_buf_set_lines
+			vim.api.nvim_buf_set_lines = function() end
+
+			notes.create_new_note()
+
+			assert.matches("/tmp/test%-vault/notes/", opened_file)
+
+			vim.fn.input = original_input
+			vim.fn.expand = original_expand
+			vim.fn.filereadable = original_filereadable
+			vim.fn.fnamemodify = original_fnamemodify
+			vim.fn.isdirectory = original_isdirectory
+			vim.cmd = original_cmd
+			vim.api.nvim_buf_set_lines = original_buf_set_lines
+		end)
+
+		it("routes create_new_note to template_dirs subdir when default_template matches", function()
+			config.options = {}
+			config.workspaces = {}
+			config.current_active_workspace = nil
+			config.setup({
+				vault_path = "/tmp/test-vault",
+				notes_subdir = "notes",
+				default_template = "private",
+				template_dirs = { ["private"] = "private" },
+			})
+
+			local original_input = vim.fn.input
+			vim.fn.input = function() return "Secret Note" end
+
+			local original_expand = vim.fn.expand
+			vim.fn.expand = function(path)
+				if path:match("^/tmp/test%-vault") then return path end
+				return original_expand(path)
+			end
+
+			local original_filereadable = vim.fn.filereadable
+			vim.fn.filereadable = function() return 0 end
+
+			local original_fnamemodify = vim.fn.fnamemodify
+			vim.fn.fnamemodify = function(path, modifier)
+				if modifier == ":h" then return "/tmp/test-vault/private" end
+				return original_fnamemodify(path, modifier)
+			end
+
+			local original_isdirectory = vim.fn.isdirectory
+			vim.fn.isdirectory = function() return 1 end
+
+			local opened_file = nil
+			local original_cmd = vim.cmd
+			vim.cmd = function(cmd)
+				if cmd:match("^edit ") then opened_file = cmd:match("^edit (.+)$") end
+			end
+
+			local original_buf_set_lines = vim.api.nvim_buf_set_lines
+			vim.api.nvim_buf_set_lines = function() end
+
+			-- Stub apply_template_to_file so default_template branch runs
+			local templates = require("markdown-notes.templates")
+			local original_apply = templates.apply_template_to_file
+			templates.apply_template_to_file = function() return true end
+
+			notes.create_new_note()
+
+			assert.matches("/tmp/test%-vault/private/", opened_file)
+			assert.matches("secret%-note%.md$", opened_file)
+
+			vim.fn.input = original_input
+			vim.fn.expand = original_expand
+			vim.fn.filereadable = original_filereadable
+			vim.fn.fnamemodify = original_fnamemodify
+			vim.fn.isdirectory = original_isdirectory
+			vim.cmd = original_cmd
+			vim.api.nvim_buf_set_lines = original_buf_set_lines
+			templates.apply_template_to_file = original_apply
+		end)
+	end)
+
 	describe("workspace integration", function()
 		it("uses workspace-specific vault path", function()
 			-- Set up workspace


### PR DESCRIPTION
## Summary

- Adds `template_dirs` config option that maps template names to subdirectories (relative to `vault_path`)
- When creating a note via `<leader>nc` (template picker), the note is placed in the mapped subdir instead of `notes_subdir`
- When `default_template` is set, `<leader>nn` also respects the `template_dirs` mapping
- Both `default_template` and `template_dirs` are supported per-workspace
- Directories are created automatically if they don't exist
- Refactors `create_from_template` to resolve the file path *after* template selection, so the destination is known before the file is created

## Example configuration

```lua
require("markdown-notes").setup({
  notes_subdir = "notes",
  template_dirs = {
    ["private"]  = "private",
    ["meeting"]  = "work/meetings",
    ["journal"]  = "journal",
  },
})
```

## Test plan

- [ ] New `template_dirs routing` tests pass (2 new cases in `notes_spec.lua`)
- [ ] All existing tests continue to pass (53 total)
- [ ] `create_from_template` places note in mapped subdir when template is selected
- [ ] `create_new_note` with `default_template` places note in mapped subdir
- [ ] Falls back to `notes_subdir` when template has no mapping
- [ ] Works correctly per-workspace with independent `template_dirs` configs