### PR TITLE
fix: resolve keybinding conflict between weekly notes and workspace picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ All keybindings use `<leader>n` as the prefix for easy discovery:
 | `<leader>nd` | Daily note (today) | Create/open today's daily note |
 | `<leader>ny` | Daily note (yesterday) | Open yesterday's daily note |
 | `<leader>nt` | Daily note (tomorrow) | Open tomorrow's daily note |
-| `<leader>nww` | Weekly note (this week) | Create/open this week's weekly note |
-| `<leader>nwl` | Weekly note (last week) | Open last week's weekly note |
-| `<leader>nwn` | Weekly note (next week) | Open next week's weekly note |
+| `<leader>nWw` | Weekly note (this week) | Create/open this week's weekly note |
+| `<leader>nWl` | Weekly note (last week) | Open last week's weekly note |
+| `<leader>nWn` | Weekly note (next week) | Open next week's weekly note |
 | `<leader>nn` | New note | Create a new note |
 | `<leader>nc` | New note from template | Create note with template selection |
 | `<leader>nf` | Find notes | Search and open existing notes |
@@ -142,7 +142,7 @@ All keybindings use `<leader>n` as the prefix for easy discovery:
 | `<leader>ng` | Search tags | Find notes by frontmatter tags |
 | `<leader>nb` | Show backlinks | Show notes linking to current note |
 | `<leader>nr` | Rename note | Rename note and update all references with preview |
-| `<leader>nW` | Pick workspace | Switch between workspaces (capital W) |
+| `<leader>nw` | Pick workspace | Switch between workspaces |
 | `gf` | Follow link | Follow link under cursor |
 
 > **💡 Tip:** All keybindings can be customized in your configuration.
@@ -164,9 +164,9 @@ If you have a `Daily.md` template, it will be automatically applied. Otherwise, 
 Weekly notes help you plan and review your week at a higher level. They use ISO week numbers for consistency:
 
 ```
-<leader>nww  →  Creates/opens this week's note (e.g., W03-2025-Weekly-Review.md)
-<leader>nwl  →  Opens last week's note
-<leader>nwn  →  Opens next week's note
+<leader>nWw  →  Creates/opens this week's note (e.g., W03-2025-Weekly-Review.md)
+<leader>nWl  →  Opens last week's note
+<leader>nWn  →  Opens next week's note
 ```
 
 Weekly notes are created with the format `W{week}-{year}-Weekly-Review.md` and automatically apply your `Weekly.md` template if available. The plugin uses ISO week numbers where:
@@ -174,8 +174,8 @@ Weekly notes are created with the format `W{week}-{year}-Weekly-Review.md` and a
 - Week 1 is the week containing the first Thursday of the year
 
 **Example workflow:**
-1. Start each week with `<leader>nww` to create your weekly planning note
-2. Review last week with `<leader>nwl` before planning the current week
+1. Start each week with `<leader>nWw` to create your weekly planning note
+2. Review last week with `<leader>nWl` before planning the current week
 3. Use template variables like `{{week_number}}`, `{{week_year}}`, and `{{week_id}}` in your Weekly template
 
 ### Creating and Managing Notes
@@ -320,9 +320,9 @@ require("markdown-notes").setup({
     daily_note_today = "<leader>nd",
     daily_note_yesterday = "<leader>ny",
     daily_note_tomorrow = "<leader>nt",
-    weekly_note_this_week = "<leader>nww",
-    weekly_note_last_week = "<leader>nwl",
-    weekly_note_next_week = "<leader>nwn",
+    weekly_note_this_week = "<leader>nWw",
+    weekly_note_last_week = "<leader>nWl",
+    weekly_note_next_week = "<leader>nWn",
     new_note = "<leader>nn",
     new_note_from_template = "<leader>nc",
     find_notes = "<leader>nf",
@@ -333,7 +333,7 @@ require("markdown-notes").setup({
     show_backlinks = "<leader>nb",
     follow_link = "gf",
     rename_note = "<leader>nr",
-    pick_workspace = "<leader>nW",
+    pick_workspace = "<leader>nw",
   },
 })
 ```
@@ -375,7 +375,7 @@ require("markdown-notes").setup_workspace("research", {
 
 #### Workspace Workflow
 
-- **Switch workspaces**: Use `<leader>nW` (capital W) to pick from available workspaces
+- **Switch workspaces**: Use `<leader>nw` to pick from available workspaces
 - **Persistent context**: All commands use the active workspace until you switch
 - **Independent settings**: Each workspace has its own paths, templates, and variables
 

--- a/doc/markdown-notes.txt
+++ b/doc/markdown-notes.txt
@@ -205,8 +205,13 @@ All keybindings use `<leader>n` as the prefix for easy discovery:
 
 Daily Notes~
 `<leader>nd`        Create/open today's daily note
-`<leader>ny`        Open yesterday's daily note  
+`<leader>ny`        Open yesterday's daily note
 `<leader>nt`        Open tomorrow's daily note
+
+Weekly Notes~
+`<leader>nWw`       Create/open this week's weekly note
+`<leader>nWl`       Open last week's weekly note
+`<leader>nWn`       Open next week's weekly note
 
 Note Management~
 `<leader>nn`        Create a new note
@@ -225,7 +230,7 @@ Templates and Tags~
 `<leader>ng`        Find notes by frontmatter tags
 
 Workspaces~
-`<leader>nW`        Pick workspace
+`<leader>nw`        Pick workspace
 
 Note: All keybindings can be customized in your configuration.
 
@@ -379,7 +384,7 @@ Setting Up Workspaces~
 
 Workspace Workflow~
                                             *markdown-notes-workspace-workflow*
-- Switch workspaces: Use `<leader>nW` to pick from available workspaces
+- Switch workspaces: Use `<leader>nw` to pick from available workspaces
 - Persistent context: All commands use the active workspace until you switch
 - Independent settings: Each workspace has its own paths, templates, and variables
 

--- a/lua/markdown-notes/config.lua
+++ b/lua/markdown-notes/config.lua
@@ -71,9 +71,9 @@ M.defaults = {
 		daily_note_today = "<leader>nd",
 		daily_note_yesterday = "<leader>ny",
 		daily_note_tomorrow = "<leader>nt",
-		weekly_note_this_week = "<leader>nww",
-		weekly_note_last_week = "<leader>nwl",
-		weekly_note_next_week = "<leader>nwn",
+		weekly_note_this_week = "<leader>nWw",
+		weekly_note_last_week = "<leader>nWl",
+		weekly_note_next_week = "<leader>nWn",
 		new_note = "<leader>nn",
 		new_note_from_template = "<leader>nc",
 		find_notes = "<leader>nf",
@@ -84,7 +84,7 @@ M.defaults = {
 		show_backlinks = "<leader>nb",
 		follow_link = "gf",
 		rename_note = "<leader>nr",
-		pick_workspace = "<leader>nW",
+		pick_workspace = "<leader>nw",
 	},
 }
 

--- a/tests/markdown-notes/keybindings_spec.lua
+++ b/tests/markdown-notes/keybindings_spec.lua
@@ -1,0 +1,36 @@
+local config = require("markdown-notes.config")
+
+local function normalize(key)
+	-- Normalize to lowercase for prefix comparison since <Leader> vs <leader> etc.
+	-- but preserve the structure — only collapse modifier case
+	return key:gsub("<[Ll]eader>", "<leader>"):gsub("<[Cc][Rr]>", "<CR>")
+end
+
+local function is_prefix(shorter, longer)
+	return shorter ~= longer and longer:sub(1, #shorter) == shorter
+end
+
+describe("keybindings", function()
+	it("default mappings have no prefix conflicts", function()
+		local mappings = config.defaults.mappings
+		local bindings = {}
+
+		for action, key in pairs(mappings) do
+			table.insert(bindings, { action = action, key = normalize(key) })
+		end
+
+		local conflicts = {}
+		for i = 1, #bindings do
+			for j = i + 1, #bindings do
+				local a, b = bindings[i], bindings[j]
+				if is_prefix(a.key, b.key) then
+					table.insert(conflicts, string.format("'%s' (%s) is a prefix of '%s' (%s)", a.key, a.action, b.key, b.action))
+				elseif is_prefix(b.key, a.key) then
+					table.insert(conflicts, string.format("'%s' (%s) is a prefix of '%s' (%s)", b.key, b.action, a.key, a.action))
+				end
+			end
+		end
+
+		assert.are.equal(0, #conflicts, "Keybinding prefix conflicts detected:\n  " .. table.concat(conflicts, "\n  "))
+	end)
+end)


### PR DESCRIPTION
## Summary

- Weekly note bindings (`<leader>nww/nwl/nwn`) shadowed `<leader>nw`, making the workspace picker unreachable since Neovim treats `nw` as a prefix and waits for additional input
- Move weekly note bindings to `<leader>nW` prefix (`nWw`, `nWl`, `nWn`) — uppercase W for Weekly
- Restore workspace picker to its original `<leader>nw` binding
- Add weekly note keybindings to `doc/markdown-notes.txt` (they were previously undocumented in the help file)

## Test plan

- [ ] Verify `<leader>nw` opens the workspace picker immediately without waiting
- [ ] Verify `<leader>nWw` opens this week's weekly note
- [ ] Verify `<leader>nWl` opens last week's weekly note
- [ ] Verify `<leader>nWn` opens next week's weekly note
- [ ] Confirm no other keybinding conflicts exist with the `nW` prefix